### PR TITLE
fix: Update task status option from 'In Progress' to 'Pending' as Zen…

### DIFF
--- a/frontend/src/components/Tasks/index.tsx
+++ b/frontend/src/components/Tasks/index.tsx
@@ -207,7 +207,7 @@ const Tasks: React.FC = () => {
                 Status:
                 <select name="status" required>
                   <option value="open">Open</option>
-                  <option value="in_progress">In Progress</option>
+                  <option value="pending">Pending</option>
                   <option value="closed">Closed</option>
                 </select>
               </label>


### PR DESCRIPTION
Update task status option from 'In Progress' to 'Pending' as Zendesk shows In Progress as Open which could be confusing.


Before 
![image](https://github.com/user-attachments/assets/1e0e052b-d9df-4e85-9483-a470c242915c)
After
![image](https://github.com/user-attachments/assets/907c7a33-0b75-4c2d-9d56-06f601004acc)
